### PR TITLE
Update UploadableFile MimeType Resolution Logic

### DIFF
--- a/AsyncNetworkService.xcodeproj/project.pbxproj
+++ b/AsyncNetworkService.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4A2BCAE228B5687B0031844D /* FileUploadRequestModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE128B5687B0031844D /* FileUploadRequestModifier.swift */; };
 		4A2BCAE528B5693F0031844D /* UploadableFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE428B5693F0031844D /* UploadableFile.swift */; };
 		4A2BCAE728B5710C0031844D /* Data+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE628B5710C0031844D /* Data+.swift */; };
+		4AA6B05A2A0579B0008BA3CF /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA6B0592A0579B0008BA3CF /* String+.swift */; };
 		4AB0D5032876099B00C36A3A /* NetworkResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */; };
 		E8A91431279B2D3800095A98 /* AsyncNetworkService.docc in Sources */ = {isa = PBXBuildFile; fileRef = E8A91430279B2D3800095A98 /* AsyncNetworkService.docc */; };
 		E8A91437279B2D3800095A98 /* AsyncNetworkService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */; };
@@ -57,6 +58,7 @@
 		4A2BCAE128B5687B0031844D /* FileUploadRequestModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadRequestModifier.swift; sourceTree = "<group>"; };
 		4A2BCAE428B5693F0031844D /* UploadableFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableFile.swift; sourceTree = "<group>"; };
 		4A2BCAE628B5710C0031844D /* Data+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+.swift"; sourceTree = "<group>"; };
+		4AA6B0592A0579B0008BA3CF /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+.swift"; path = "../../../AsyncHTTPNetworkService-RP/AsyncNetworkService/Extensions/String+.swift"; sourceTree = "<group>"; };
 		4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponseInterceptor.swift; sourceTree = "<group>"; };
 		8347924927FCBCC100AFDDF3 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncNetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -181,6 +183,7 @@
 				E8A9145C279B386800095A98 /* Codable+.swift */,
 				E8A9145E279B3AE300095A98 /* JSONDecoder+.swift */,
 				E8A91460279B3B0F00095A98 /* DateFormatter+.swift */,
+				4AA6B0592A0579B0008BA3CF /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				E8A91461279B3B0F00095A98 /* DateFormatter+.swift in Sources */,
 				E8A91447279B2F5F00095A98 /* AsyncHTTPNetworkService.swift in Sources */,
 				E8A9144C279B308900095A98 /* URLRequest+.swift in Sources */,
+				4AA6B05A2A0579B0008BA3CF /* String+.swift in Sources */,
 				E8A91457279B33F500095A98 /* NotificationObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -580,7 +584,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -609,7 +613,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/AsyncNetworkService.xcodeproj/project.pbxproj
+++ b/AsyncNetworkService.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		4A2BCAE228B5687B0031844D /* FileUploadRequestModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE128B5687B0031844D /* FileUploadRequestModifier.swift */; };
 		4A2BCAE528B5693F0031844D /* UploadableFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE428B5693F0031844D /* UploadableFile.swift */; };
 		4A2BCAE728B5710C0031844D /* Data+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2BCAE628B5710C0031844D /* Data+.swift */; };
-		4AA6B05A2A0579B0008BA3CF /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA6B0592A0579B0008BA3CF /* String+.swift */; };
+		4AA6B05C2A057DA0008BA3CF /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA6B05B2A057DA0008BA3CF /* String+.swift */; };
 		4AB0D5032876099B00C36A3A /* NetworkResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */; };
 		E8A91431279B2D3800095A98 /* AsyncNetworkService.docc in Sources */ = {isa = PBXBuildFile; fileRef = E8A91430279B2D3800095A98 /* AsyncNetworkService.docc */; };
 		E8A91437279B2D3800095A98 /* AsyncNetworkService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */; };
@@ -58,7 +58,7 @@
 		4A2BCAE128B5687B0031844D /* FileUploadRequestModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadRequestModifier.swift; sourceTree = "<group>"; };
 		4A2BCAE428B5693F0031844D /* UploadableFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadableFile.swift; sourceTree = "<group>"; };
 		4A2BCAE628B5710C0031844D /* Data+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+.swift"; sourceTree = "<group>"; };
-		4AA6B0592A0579B0008BA3CF /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "String+.swift"; path = "../../../AsyncHTTPNetworkService-RP/AsyncNetworkService/Extensions/String+.swift"; sourceTree = "<group>"; };
+		4AA6B05B2A057DA0008BA3CF /* String+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		4AB0D5022876099B00C36A3A /* NetworkResponseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponseInterceptor.swift; sourceTree = "<group>"; };
 		8347924927FCBCC100AFDDF3 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E8A9142C279B2D3800095A98 /* AsyncNetworkService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AsyncNetworkService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,13 +177,13 @@
 		E8A9144A279B306700095A98 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				4AA6B05B2A057DA0008BA3CF /* String+.swift */,
 				4A2BCAE628B5710C0031844D /* Data+.swift */,
 				E8A9144B279B308900095A98 /* URLRequest+.swift */,
 				E8A9144D279B309900095A98 /* URL+.swift */,
 				E8A9145C279B386800095A98 /* Codable+.swift */,
 				E8A9145E279B3AE300095A98 /* JSONDecoder+.swift */,
 				E8A91460279B3B0F00095A98 /* DateFormatter+.swift */,
-				4AA6B0592A0579B0008BA3CF /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -410,7 +410,7 @@
 				E8A91461279B3B0F00095A98 /* DateFormatter+.swift in Sources */,
 				E8A91447279B2F5F00095A98 /* AsyncHTTPNetworkService.swift in Sources */,
 				E8A9144C279B308900095A98 /* URLRequest+.swift in Sources */,
-				4AA6B05A2A0579B0008BA3CF /* String+.swift in Sources */,
+				4AA6B05C2A057DA0008BA3CF /* String+.swift in Sources */,
 				E8A91457279B33F500095A98 /* NotificationObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AsyncNetworkService/Common/Models/UploadableFile.swift
+++ b/AsyncNetworkService/Common/Models/UploadableFile.swift
@@ -16,7 +16,7 @@ public struct UploadableFile {
     public let additionalContent: [ContentName: ContentValue]
     public let fileName: String
 
-    public init(data: Data, fieldName: String, additionalContent: [ContentName: ContentValue] = [:], fileName: String) {
+    public init(data: Data, fileName: String, fieldName: String = "files", additionalContent: [ContentName: ContentValue] = [:]) {
         self.data = data
         self.fieldName = fieldName
         self.additionalContent = additionalContent

--- a/AsyncNetworkService/Common/Models/UploadableFile.swift
+++ b/AsyncNetworkService/Common/Models/UploadableFile.swift
@@ -16,7 +16,7 @@ public struct UploadableFile {
     public let additionalContent: [ContentName: ContentValue]
     public let fileName: String
 
-    /// Creates an object representation of a file with associated data required for a POST upload
+    /// Creates an object representation of a file with associated data required for a POST upload request 
     ///
     /// ```
     /// UploadableFile(data: pdfData, fileName: "myfile.pdf")
@@ -29,9 +29,7 @@ public struct UploadableFile {
     ///   - additionalContent: Additional key value pairs that will be appended to the `Content-Disposition` header as properties
     ///
     ///
-    /// - Returns: Void if deletion succeeds
-    ///
-    /// - Throws: `NetworkError` if deletion fails
+    /// - Returns: UploadableFile
     
     public init(data: Data, fileName: String, fieldName: String = "files", additionalContent: [ContentName: ContentValue] = [:]) {
         self.data = data

--- a/AsyncNetworkService/Common/Models/UploadableFile.swift
+++ b/AsyncNetworkService/Common/Models/UploadableFile.swift
@@ -16,7 +16,7 @@ public struct UploadableFile {
     public let additionalContent: [ContentName: ContentValue]
     public let fileName: String
 
-    public init(data: Data, fieldName: String, additionalContent: [ContentName: ContentValue] = [:], fileName: String = UUID().uuidString) {
+    public init(data: Data, fieldName: String, additionalContent: [ContentName: ContentValue] = [:], fileName: String) {
         self.data = data
         self.fieldName = fieldName
         self.additionalContent = additionalContent

--- a/AsyncNetworkService/Common/Models/UploadableFile.swift
+++ b/AsyncNetworkService/Common/Models/UploadableFile.swift
@@ -16,6 +16,23 @@ public struct UploadableFile {
     public let additionalContent: [ContentName: ContentValue]
     public let fileName: String
 
+    /// Creates an object representation of a file with associated data required for a POST upload
+    ///
+    /// ```
+    /// UploadableFile(data: pdfData, fileName: "myfile.pdf")
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - data: Raw file data
+    ///   - fileName: The name of the file. This will be used in the `Content-Disposition` header on a POST request. Ensure the file extension is specified as the framework relies on it to resolve the MimeType.
+    ///   - fieldName: The value for `name` property in the `Content-Disposition` header
+    ///   - additionalContent: Additional key value pairs that will be appended to the `Content-Disposition` header as properties
+    ///
+    ///
+    /// - Returns: Void if deletion succeeds
+    ///
+    /// - Throws: `NetworkError` if deletion fails
+    
     public init(data: Data, fileName: String, fieldName: String = "files", additionalContent: [ContentName: ContentValue] = [:]) {
         self.data = data
         self.fieldName = fieldName

--- a/AsyncNetworkService/Common/RequestModifiers/FileUploadRequestModifier.swift
+++ b/AsyncNetworkService/Common/RequestModifiers/FileUploadRequestModifier.swift
@@ -25,13 +25,13 @@ struct FileUploadRequestModifier: NetworkRequestModifier {
         var combinedData = Data()
         files.forEach {
             var postContent = ""
-            let fileName = "\($0.fileName).\($0.data.fileExtension)"
+            let fileName = "\($0.fileName)"
 
             postContent += "\r\n"
             postContent += "--\(boundary)"
             postContent += "\r\n"
             postContent += "Content-Disposition: form-data; name=\"\($0.fieldName)\"; filename=\"\(fileName)\"\r\n"
-            postContent += "Content-Type: \($0.data.mimeType)"
+            postContent += "Content-Type: \($0.fileName.mimeType)"
             postContent += "\r\n\r\n"
             
             guard let postData = postContent.data(using: .utf8) else { return }

--- a/AsyncNetworkService/Extensions/Data+.swift
+++ b/AsyncNetworkService/Extensions/Data+.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 extension Data {
-    var mimeType: String {
+    public var mimeType: String {
         switch mimeUInt {
         case 0xFF:
             return "image/jpeg"
@@ -22,7 +22,7 @@ extension Data {
         }
     }
 
-    var fileExtension: String {
+    public var fileExtension: String {
         switch mimeUInt {
         case 0xFF:
             return "jpg"

--- a/AsyncNetworkService/Extensions/Data+.swift
+++ b/AsyncNetworkService/Extensions/Data+.swift
@@ -42,4 +42,8 @@ extension Data {
         copyBytes(to: &values, count: 1)
         return values.first ?? 0
     }
+    
+    var jsonString: String? {
+        String(data: self, encoding: .utf8)
+    }
 }

--- a/AsyncNetworkService/Extensions/Data+.swift
+++ b/AsyncNetworkService/Extensions/Data+.swift
@@ -43,7 +43,7 @@ extension Data {
         return values.first ?? 0
     }
     
-    var jsonString: String? {
+    public var jsonString: String? {
         String(data: self, encoding: .utf8)
     }
 }

--- a/AsyncNetworkService/Extensions/String+.swift
+++ b/AsyncNetworkService/Extensions/String+.swift
@@ -1,0 +1,26 @@
+//
+//  String+.swift
+//  AsyncNetworkService
+//
+//  Created by Alex Maslov on 2023-05-05.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+extension NSString {
+    public var mimeType: String {
+        if let mimeType = UTType(filenameExtension: self.pathExtension)?.preferredMIMEType {
+            return mimeType
+        }
+        else {
+            return "application/octet-stream"
+        }
+    }
+}
+
+extension String {
+    public var mimeType: String {
+        return (self as NSString).mimeType
+    }
+}

--- a/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
+++ b/AsyncNetworkServiceTests/AsyncNetworkServiceTests.swift
@@ -617,13 +617,13 @@ class AsyncNetworkServiceTests: XCTestCase {
         // Sample test file mock file data for upload
         let files: [UploadableFile] = [
             // image with no additional data
-            .init(data: fileData1, fieldName: "images", fileName: "file name 1"),
+            .init(data: fileData1, fileName: "file name 1.jpg", fieldName: "images"),
             
             // image with additional data
             .init(data: fileData2,
+                  fileName: "file name 2.jpg",
                   fieldName: "images",
-                  additionalContent: ["property name1": "property value1", "property name2": "property value2"],
-                  fileName: "file name 2"),
+                  additionalContent: ["property name1": "property value1", "property name2": "property value2"]),
         ]
         
         request = request.withFiles(files: files, boundary: "CCC574E7-15E1-40BA-B3D3-679F20F3E2EC-29057-00026EB0E2E684C0")

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
 // swift-tools-version:5.5
 import PackageDescription
 
+
 let package = Package(
     name: "AsyncNetworkService",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v14),
         .macOS(.v10_15),
     ],
     products: [


### PR DESCRIPTION
Shift from using raw data hex values to determine mimetypes of files to resolving mimetypes by analyzing the supplied filename extension. As a result, the `filename` property on `UploadableFile` is now mandatory and no longer optional.

Updated `UploadableFile` constructor:
<img width="498" alt="image" src="https://user-images.githubusercontent.com/18052531/236552092-d4792889-1c14-4cd4-a359-d5763edc0fb1.png">
