### PR TITLE
Make URLSessionConfiguration Injectable

### DIFF
--- a/AsyncNetworkService/AsyncHTTPNetworkService.swift
+++ b/AsyncNetworkService/AsyncHTTPNetworkService.swift
@@ -28,18 +28,20 @@ public class AsyncHTTPNetworkService: AsyncNetworkService {
     public var requestModifiers: [NetworkRequestModifier]
     public var responseInterceptors: [NetworkResponseInterceptor]
 
-    private let urlSession = URLSession(configuration: .ephemeral)
+    private let urlSession: URLSession
 
     public var errorHandlers: [AsyncNetworkErrorHandler] = []
 
     public init(
         requestModifiers: [NetworkRequestModifier] = [],
         errorHandlers: [AsyncNetworkErrorHandler] = [],
-        reponseInterceptors: [NetworkResponseInterceptor] = []
+        reponseInterceptors: [NetworkResponseInterceptor] = [],
+        urlSessionConfiguration: URLSessionConfiguration = .ephemeral
     ) {
         self.requestModifiers = requestModifiers
         self.errorHandlers = errorHandlers
         self.responseInterceptors = reponseInterceptors
+        self.urlSession = URLSession(configuration: urlSessionConfiguration)
     }
 
     private func applyModifiers(to request: ConvertsToURLRequest) -> URLRequest {


### PR DESCRIPTION
Allows the caller to instantiate the service with a supplied `URLSessionConfiguration`